### PR TITLE
Fix various issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,6 @@ option(SSP4C_BUILD_TEST "Build test executable" OFF)
 option(SSP4C_BUILD_SHARED "Build as shared library (DLL)" ON)
 option(SSP4C_USE_SYSTEM_ZIP "Use system utilities for unzipping" ON)
 option(SSP4C_USE_INCLUDED_ZLIB "Use the included zlib (statically linked) even if a system version is available" OFF)
-#this option is only enabled when SSP4C_USE_SYSTEM_ZIP=OFF
-cmake_dependent_option(SSP4C_USE_INCLUDED_ZLIB "Use the included zlib (statically linked) even if a system version is available" OFF "NOT SSP4C_USE_SYSTEM_ZIP" OFF)
 
 if (NOT DEFINED SSP4C_EXTERNAL_MINIZIP)
     set(SSP4C_EXTERNAL_MINIZIP "" CACHE STRING "Defines an external target for minizip.")
@@ -20,7 +18,7 @@ endif()
 
 # Set default debug postfix
 if (NOT CMAKE_DEBUG_POSTFIX)
-    set(CMAKE_DEBUG_POSTFIX )
+    set(CMAKE_DEBUG_POSTFIX "d")
 endif()
 
 if (${SSP4C_BUILD_DOCUMENTATION})
@@ -174,7 +172,7 @@ else()
         target_link_libraries(ssp4c PRIVATE ZLIB::ZLIB)
         target_compile_definitions(ssp4c PRIVATE SSP4C_WITH_MINIZIP)
     else()
-        message(STATUS "Using esystem zip")
+        message(STATUS "Using system zip")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ target_include_directories(ssp4c
 )
 
 if(NOT SSP4C_USE_EXTERNAL_MINIZIP)
-    target_include_directories(ssp4c PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty>/minizip")
+    target_include_directories(ssp4c PRIVATE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/minizip>")
 endif()
 
 # Internal dependecy (PRIVATE) on zlib and ${CMAKE_DL_LIBS}) for libdl on Linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.10)
 project(ssp4c C)
 set(CMAKE_C_STANDARD 99)
 

--- a/src/ssp4c.c
+++ b/src/ssp4c.c
@@ -7,7 +7,6 @@
 #include <string.h>
 #include <stdlib.h>
 #ifndef _WIN32
-#include "ssp4c.h"
 #include <dlfcn.h>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -136,7 +135,7 @@ bool ssp4c_saveSsp(sspHandle *h, const char *sspfile)
         else
         {
             const char* xmlText = ezxml_toxml(h->ssds[i].xml);
-            fprintf(fp, xmlText);
+            fprintf(fp, "%s", xmlText);
             freeDuplicatedConstChar(xmlText);
             fclose(fp);
         }

--- a/src/ssp4c_ssd_component.c
+++ b/src/ssp4c_ssd_component.c
@@ -2,6 +2,8 @@
 #include "ssp4c_ssd_component.h"
 #include "ssp4c_xml_constants.h"
 
+#include <string.h>
+
 const char* ssp4c_ssd_component_getName(ssdComponentHandle *h)
 {
     return ezxml_attr(h->xml, XML_ATTR_NAME);

--- a/src/ssp4c_ssd_connection_geometry.c
+++ b/src/ssp4c_ssd_connection_geometry.c
@@ -3,6 +3,8 @@
 #include "ssp4c_utils.h"
 #include "ssp4c_xml_constants.h"
 
+#include <string.h>
+
 double *ssp4c_ssd_connectionGeometry_getPointsX(ssdConnectionGeometryHandle *h, int *n)
 {
     *n = 0;

--- a/src/ssp4c_ssd_connector.c
+++ b/src/ssp4c_ssd_connector.c
@@ -2,6 +2,8 @@
 #include "ssp4c_ssd_connector.h"
 #include "ssp4c_xml_constants.h"
 
+#include <string.h>
+
 const char* ssp4c_ssd_connector_getName(ssdConnectorHandle *h)
 {
     return ezxml_attr(h->xml, XML_ATTR_NAME);

--- a/src/ssp4c_ssd_parameter_binding.c
+++ b/src/ssp4c_ssd_parameter_binding.c
@@ -2,6 +2,8 @@
 #include "ssp4c_ssd_parameter_binding.h"
 #include "ssp4c_xml_constants.h"
 
+#include <string.h>
+
 const char *ssp4c_ssd_parameterBinding_getType(ssdParameterBindingHandle *h)
 {
     return ezxml_attr(h->xml, XML_ATTR_TYPE);

--- a/src/ssp4c_ssd_parameter_mapping.c
+++ b/src/ssp4c_ssd_parameter_mapping.c
@@ -2,6 +2,8 @@
 #include "ssp4c_ssd_parameter_mapping.h"
 #include "ssp4c_xml_constants.h"
 
+#include <string.h>
+
 const char *ssp4c_ssd_parameterMapping_getDescription(ssdParameterMappingHandle *h)
 {
     return ezxml_attr(h->xml, XML_ATTR_DESCRIPTION);

--- a/src/ssp4c_ssv_parameter.c
+++ b/src/ssp4c_ssv_parameter.c
@@ -3,6 +3,8 @@
 #include "ssp4c_xml_constants.h"
 #include "ssp4c_utils.h"
 
+#include <string.h>
+
 const char *ssp4c_ssv_parameter_getName(ssvParameterHandle *h)
 {
     return ezxml_attr(h->xml, XML_ATTR_NAME);

--- a/src/ssp4c_xml_parsers.c
+++ b/src/ssp4c_xml_parsers.c
@@ -4,6 +4,11 @@
 #include "ssp4c_xml_parsers.h"
 #include "ssp4c_utils.h"
 
+#include <string.h>
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+
 static bool parseSsdSystem(ssdHandle *ssd, ezxml_t systemElement, sspHandle *ssp)
 {
     if (!systemElement) {
@@ -385,6 +390,7 @@ bool parseSsm(sspHandle *ssp, ssmParameterMappingHandle *ssm, const char *path)
     parseSsmParameterMappingElement(ssm->xml, ssm, ssp);
     printf("Finished parsing SSM file: %s\n", path);
     chdir(cwd);
+    return true;
 }
 
 bool parseSsmParameterMappingElement(ezxml_t element, ssmParameterMappingHandle *h, sspHandle *ssp)


### PR DESCRIPTION
- Missing return
- Missing string.h includes
- Missing fprintf format string
- Set cmake minimum 3.10 to avoid deprecation warnings or failures